### PR TITLE
feat: 확장 프로그램 팝업 UI 구성 및 CSP 오류 수정, 확장 프로그램 버전 자동 업데이트 방식 개선

### DIFF
--- a/.github/workflows/deploy-extension.yml
+++ b/.github/workflows/deploy-extension.yml
@@ -37,11 +37,12 @@ jobs:
       - name: Auto bump manifest version + version_name
         run: |
           current=$(jq -r '.version' public/manifest.json)
-          current_patch=$(echo "$current" | awk -F. '{print $4}')
-          next_patch=$((current_patch + 1))
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$current"
 
-          version="$MAJOR.$MINOR.$PATCH.$next_patch"
-          version_name="Delook v$MAJOR.$MINOR.$PATCH • build $next_patch"
+          today=$(date "+%Y.%m.%d")
+
+          version="$MAJOR.$MINOR.$PATCH"
+          version_name="$MAJOR.$MINOR.$PATCH ($today)"
 
           echo "Bumping version to $version"
           jq ".version = \"$version\" | .version_name = \"$version_name\"" public/manifest.json > tmp.json && mv tmp.json public/manifest.json

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>디룩 | Delook</title>
+  </head>
+  <body>
+    <div id="popup-root"></div>
+    <script type="module" src="/src/popup.tsx"></script>
+  </body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,7 +6,7 @@
   "version": "1.0.0",
   "description": "디룩은 새 탭을 열 때마다 랜덤한 프로그래밍 개념을 보여주어, 자연스럽게 지식을 확장할 수 있도록 돕는 확장 프로그램입니다.  꾸준한 학습을 통해 기술 면접과 실무에 자신감을 더하세요.",
   "action": {
-    "default_popup": "index.html",
+    "default_popup": "popup.html",
     "default_icon": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,0 +1,21 @@
+import './styles/index.css'; // ✅ Tailwind 포함
+
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+export const Popup = () => {
+  return (
+    <div className="flex h-[150px] w-[400px] flex-col items-center justify-center bg-white px-6 py-8 text-center text-gray-800">
+      <h1 className="mb-2 text-lg font-semibold">Delook은 새 탭에서만 이용할 수 있어요!</h1>
+      <span className="text-sm text-gray-500">
+        브라우저 설정에서 Delook을 시작 페이지로 지정해 주세요.
+      </span>
+    </div>
+  );
+};
+
+createRoot(document.getElementById('popup-root')!).render(
+  <StrictMode>
+    <Popup />
+  </StrictMode>,
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
       postProcess(renderedRoute) {
         renderedRoute.html = renderedRoute.html
           .replace(/http:/i, 'https:')
-          .replace(/(https:\/\/)?(localhost|127\.0\.0\.1):\d*/i, 'https://delook.co.kr');
+          .replace(/(https:\/\/)?(localhost|127\.0\.0\.1):\d*/i, '.');
       },
     }),
   ],
@@ -61,6 +61,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         main: './index.html',
+        popup: './popup.html',
       },
       output: {
         manualChunks: {


### PR DESCRIPTION
## 👀 관련 이슈
Close #49 
Close #50 

## 📌 유형

- [ ] 콘텐츠 기여
- [x] 기능 추가/삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타 (설명 필요)

## ✨ 세부 내용
- 확장 프로그램 popup UI 설정 , 새 탭에서만 이용할 수 있음을 알리도록 구성 
    <img width="488" alt="스크린샷 2025-05-09 오후 5 03 27" src="https://github.com/user-attachments/assets/b59705aa-9d93-40c2-a5cf-2e5aaba7b0f6" />

- CSP 오류 수정
  - 문제 원인:  vite.config.ts에 작성한 `prerender` 옵션에서의 문제로 파악. 
 Chrome 확장 프로그램에서 새 탭(chrome-extension://)을 렌더링할 때,
vite.config.ts의 prerender 옵션 내 postProcess()에서 HTML 내 주소를 절대 URL(https://delook.co.kr)로 치환하는 로직이 원인이 되어 CSP(Content Security Policy) 위반이 발생함.

   - 해결 방법
      https://delook.co.kr을 .으로 대체해 상대 경로로 수정하여
      chrome-extension:// 환경에서도 CSP 위반 없이 정상적으로 스크립트가 로드되도록 개선함.

-  확장 프로그램 버전 자동 업데이트 방식 개선
  main 브랜치에 병합할 때마다 버전이 추가되는 문제 발생 ex. 1.0.0 version 4
  불분명한 숫자 대신  당일 날짜를 자동으로 포함하도록 개선 ex. 1.0.0 (2025.05.09)

<!--
- 콘텐츠 기여 유형 선택 시 [category]와 함께 작성해주세요
예: "[cs] 스택(Stack) 자료구조 설명 작성"
-->

## 📚 관련 문서 / 참고 자료

 <!-- 참고한 문서 또는 관련 자료가 있다면 작성해주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 아래 항목들을 확인하고 체크해주세요. -->

- [x] 관련 이슈가 생성되었으며, 해당 이슈 번호가 PR에 포함되었습니다.

### 📘 콘텐츠 기여 시
- [ ] [CONTRIBUTING.md](https://github.com/delook-dev/delook/blob/main/CONTRIBUTING.md)를 읽고 기여 가이드를 숙지했습니다.
- [ ] 작성한 콘텐츠가 복사/붙여넣기가 아닌, 직접 작성된 것임을 확인했습니다.
- [ ] 기존에 없는 새로운 내용을 기여하고 있음을 확인했습니다.
- [ ] 내용이 기술적으로 정확하며, 오해의 소지가 없는지 검토했습니다.
- [ ] 필요한 경우, 참고할만한 문서나 링크를 추가했습니다.

### 🛠 기능/리팩토링/버그 수정 시

- [x] 기능이 정상 동작하는지 확인했습니다.
- [x] Lint 오류가 없음을 확인했습니다.

## 🚀 기타 참고 사항 / 리뷰 요구 사항

<!-- 리뷰어가 알면 좋을 추가 정보 또는 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->
